### PR TITLE
Fixed error when removing file selection

### DIFF
--- a/dist/angular-csv-import.js
+++ b/dist/angular-csv-import.js
@@ -47,8 +47,11 @@ csvImport.directive('ngCsvImport', function() {
 			});
 
 			element.on('change', function(onChangeEvent) {
-				var reader = new FileReader();
+				if (!onChangeEvent.target.files.length){
+					return;
+				}
 				scope.filename = onChangeEvent.target.files[0].name;
+				var reader = new FileReader();
 				reader.onload = function(onLoadEvent) {
 					scope.$apply(function() {
 						var content = {


### PR DESCRIPTION
When selecting a file and then removing the selection onChangeEvent.target.files[0] was undefined, and therefore accessing the name of the first file through "cannot read property 'name' of undefined". Now the change function checks whether there is selection