### PR TITLE
Limit maximum file size before processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ A variable which will contain the result of the CSV to JSON marshalling.
 
 An optional variable to limit what file types are accepted. Ex. ".csv" to only accept csv file types.
 
+- **csv.acceptSize**
+
+An optional variable to limit the size of the files that are accepted in bytes. Ex. "1024" to only accept files up to 1kB.
+
+- **csv.acceptSizeExceedCallback**
+
+An optional variable to pass in a callback to execute if the user attempted to upload a file larger than csv.acceptSize. Will run instead of parsing.
+
 - **csv.callback**
 
 An optional variable to pass in a callback to execute once the file has been parsed. Will run following any successful parsing (ie change file, change separator, etc...).

--- a/lib/angular-csv-import.js
+++ b/lib/angular-csv-import.js
@@ -17,6 +17,8 @@ csvImport.directive('ngCsvImport', function() {
 			encoding: '=?',
 			encodingVisible: '=?',
 			accept: '=?',
+			acceptSize: '=?',
+			acceptSizeExceedCallback: '=?',
 			callback: '=?'
 		},
 		template: '<div>'+
@@ -31,6 +33,7 @@ csvImport.directive('ngCsvImport', function() {
 		link: function(scope, element) {
 			scope.separatorVisible = scope.separatorVisible || false;
 			scope.headerVisible = scope.headerVisible || false;
+			scope.acceptSize = scope.acceptSize || Number.POSITIVE_INFINITY;
 
 			angular.element(element[0].querySelector('.separator-input')).on('keyup', function(e) {
 				if ( scope.content != null ) {
@@ -42,7 +45,7 @@ csvImport.directive('ngCsvImport', function() {
 					};
 					scope.result = csvToJSON(content);
 					scope.$apply();
-					if ( typeof scope.callback == 'function' ) {
+					if ( typeof scope.callback === 'function' ) {
 						scope.callback(e);
 					}
 				}
@@ -52,6 +55,14 @@ csvImport.directive('ngCsvImport', function() {
 				if (!onChangeEvent.target.files.length){
 					return;
 				}
+
+				if (onChangeEvent.target.files[0].size > scope.acceptSize){
+					if ( typeof scope.acceptSizeExceedCallback === 'function' ) {
+						scope.acceptSizeExceedCallback(onChangeEvent.target.files[0]);
+					}
+					return;
+				}
+
 				scope.filename = onChangeEvent.target.files[0].name;
 				var reader = new FileReader();
 				reader.onload = function(onLoadEvent) {
@@ -65,7 +76,7 @@ csvImport.directive('ngCsvImport', function() {
 						scope.result = csvToJSON(content);
 						scope.result.filename = scope.filename;
 						scope.$$postDigest(function(){
-							if ( typeof scope.callback == 'function' ) {
+							if ( typeof scope.callback === 'function' ) {
 								scope.callback(onChangeEvent);
 							}
 						});
@@ -83,7 +94,7 @@ csvImport.directive('ngCsvImport', function() {
 						};
 						scope.result = csvToJSON(content);
 						scope.$$postDigest(function(){
-							if ( typeof scope.callback == 'function' ) {
+							if ( typeof scope.callback === 'function' ) {
 								scope.callback(onChangeEvent);
 							}
 						});

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-csv-import",
   "author": "Bahaaldine AZARMI <bahaaldine@gmail.com>",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "main": "./lib/angular-csv-import.js",
   "engines": {
     "node": ">= 0.10.0"


### PR DESCRIPTION
Currently, a large file may be uploaded and crash the browser (e.g. a 15 MB binary file or a very large CSV).

This pull request offers the possibility to limit the maximum allowed file size before processing begins.

We'd be happy to apply any changes you deem necessary to fulfill your quality expectations and have this merged back into your branch.

Thank you for the great work!