### PR TITLE
New feacture: Import same csv file again;

### DIFF
--- a/dist/angular-csv-import.js
+++ b/dist/angular-csv-import.js
@@ -26,7 +26,8 @@ csvImport.directive('ngCsvImport', function() {
 			mdInputClass: '@?',
 			mdButtonTitle: '@?',
 			mdSvgIcon: '@?',
-			uploadButtonLabel: '='
+			uploadButtonLabel: '=',
+			lockImportSameFile:'=?'
 		},
 		template: function(element, attrs) {
 			var material = angular.isDefined(attrs.material);
@@ -142,6 +143,10 @@ csvImport.directive('ngCsvImport', function() {
 							}
 						});
 					}
+				}
+				
+				if(!scope.lockImportSameFile){
+					angular.element(document).find('.ng-csv-import.ng-isolate-scope input[type="file"]')[0].value = null;
 				}
 			});
 


### PR DESCRIPTION
When a user selects the same file, the event "change" is not fired. A new attribute has added in directive: lockImportSameFile. If this is true, the directive works like today, if attr is "undefined" or "false", this directive removes the value from input [type = "file"] and unlock the "change" event.