### PR TITLE
Fixed isssue that prevents to use separator chars that needs to be escaped

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,6 @@ language: node_js
 node_js:
   - 0.8
   - 0.10
+  - 7
 before_install:
   - npm update npm -g

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-  - 0.8
-  - 0.10
-  - 7
+  - 8
 before_install:
   - npm update npm -g

--- a/lib/angular-csv-import.js
+++ b/lib/angular-csv-import.js
@@ -157,7 +157,7 @@ csvImport.directive('ngCsvImport', function() {
 
 				for (var i=start; i<lines.length; i++) {
 					var obj = {};
-					var currentline=lines[i].split(new RegExp(content.separator+'(?![^"]*"(?:(?:[^"]*"){2})*[^"]*$)'));
+					var currentline=lines[i].split(new RegExp('\\'+content.separator+'(?![^"]*"(?:(?:[^"]*"){2})*[^"]*$)'));
 					if ( currentline.length === columnCount ) {
 						if (content.header) {
 							for (var j=0; j<headers.length; j++) {


### PR DESCRIPTION
If you are going to use separator character that needs to be escaped (like | (pipe) for example) splitting line to columns works incorrect